### PR TITLE
DEV-2776 Implement graceful shutdown [WIP]

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -5,11 +5,11 @@ from viaa.configuration import ConfigParser
 from viaa.observability import logging
 
 from app.services.db import DbClient, DuplicateKeyError, SipDelivery
-from app.services.pulsar import PulsarClient, Timeout
+from app.services.pulsar import PulsarClient, PulsarClientTimeoutException
 
 from . import APP_NAME
 
-RECEIVE_MESSAGE_TIMEOUT = 60 * 1000
+RECEIVE_MESSAGE_TIMEOUT_IN_MS = 60 * 1000
 
 
 class EventListener:
@@ -127,8 +127,8 @@ class EventListener:
         # (cf. start_listening) gets checked, we must ensure that receive_message
         # does not block indefinitely.
         try:
-            msg = self.pulsar_client.receive(timeout_millis=RECEIVE_MESSAGE_TIMEOUT)
-        except Timeout:
+            msg = self.pulsar_client.receive(timeout_millis=RECEIVE_MESSAGE_TIMEOUT_IN_MS)
+        except PulsarClientTimeoutException:
             return
 
         try:

--- a/app/app.py
+++ b/app/app.py
@@ -1,11 +1,15 @@
+import signal
+from types import FrameType
 from cloudevents.events import Event, EventAttributes, EventOutcome, PulsarBinding
 from viaa.configuration import ConfigParser
 from viaa.observability import logging
 
 from app.services.db import DbClient, DuplicateKeyError, SipDelivery
-from app.services.pulsar import PulsarClient
+from app.services.pulsar import PulsarClient, Timeout
 
 from . import APP_NAME
+
+RECEIVE_MESSAGE_TIMEOUT = 60 * 1000
 
 
 class EventListener:
@@ -18,6 +22,15 @@ class EventListener:
         self.db_client = DbClient(config_parser)
         self.log = logging.get_logger(__name__, config=config_parser)
         self.pulsar_client = PulsarClient(config_parser)
+        self.should_continue = True
+
+    def _stop(self, _signum: int | None, _frame: FrameType | None):
+        """Stops the start_listening loop once current event has been processed."""
+        self.log.info(
+            f"{EventListener.__name__} received a stop signal. "
+            "Attempting to shut down gracefully."
+        )
+        self.should_continue = False
 
     def _build_payload_event(
         self, sip_delivery: SipDelivery, message: str | None = None
@@ -108,7 +121,16 @@ class EventListener:
         self.pulsar_client.produce_event(topic, event)
 
     def receive_message(self) -> None:
-        msg = self.pulsar_client.receive()
+        # We use a timeout for PulsarClient.receive because otherwise this is
+        # a blocking method that is not guaranteed to return or throw.
+        # In order to ensure that the main application loop condition
+        # (cf. start_listening) gets checked, we must ensure that receive_message
+        # does not block indefinitely.
+        try:
+            msg = self.pulsar_client.receive(timeout_millis=RECEIVE_MESSAGE_TIMEOUT)
+        except Timeout:
+            return
+
         try:
             event = PulsarBinding.from_protocol(msg)  # type: ignore
             self.handle_incoming_message(event)
@@ -122,6 +144,14 @@ class EventListener:
         """
         Starts listening for incoming messages from the Pulsar topic.
         """
-        while True:
+
+        # Add stop handler for SIGTERM and SIGINT signals. This sets
+        # self.should_continue to false and ensures that the main loop exits
+        # gracefully.
+        signal.signal(signal.SIGTERM, self._stop)
+        signal.signal(signal.SIGINT, self._stop)
+
+        while self.should_continue:
             self.receive_message()
+
         self.pulsar_client.close()

--- a/app/app.py
+++ b/app/app.py
@@ -9,7 +9,7 @@ from app.services.pulsar import PulsarClient, PulsarClientTimeoutException
 
 from . import APP_NAME
 
-RECEIVE_MESSAGE_TIMEOUT_IN_MS = 60 * 1000
+RECEIVE_MESSAGE_TIMEOUT_IN_MS = 10 * 1000
 
 
 class EventListener:

--- a/app/services/pulsar.py
+++ b/app/services/pulsar.py
@@ -7,12 +7,12 @@ from viaa.observability import logging
 from .. import APP_NAME
 
 
-class Timeout(Exception):
+class PulsarClientTimeoutException(Exception):
     def __repr__(self) -> str:
-        return f"{Timeout.__name__}()"
+        return f"{PulsarClientTimeoutException.__name__}()"
 
     def __str__(self) -> str:
-        return "Timeout Exception"
+        return f"{PulsarClientTimeoutException.__name__}"
 
 
 class PulsarClient:
@@ -64,7 +64,7 @@ class PulsarClient:
         try:
             return self.consumer.receive(timeout_millis=timeout_millis)
         except pulsar.Timeout:
-            raise Timeout()
+            raise PulsarClientTimeoutException()
 
     def acknowledge(self, msg):
         """Acknowledge a message on the consumer.

--- a/app/services/pulsar.py
+++ b/app/services/pulsar.py
@@ -1,9 +1,18 @@
 from cloudevents.events import CEMessageMode, Event, PulsarBinding
+import pulsar
 from pulsar import Client
 from viaa.configuration import ConfigParser
 from viaa.observability import logging
 
 from .. import APP_NAME
+
+
+class Timeout(Exception):
+    def __repr__(self) -> str:
+        return f"{Timeout.__name__}()"
+
+    def __str__(self) -> str:
+        return "Timeout Exception"
 
 
 class PulsarClient:
@@ -46,13 +55,16 @@ class PulsarClient:
             event_timestamp=event.get_event_time_as_int(),
         )
 
-    def receive(self):
+    def receive(self, timeout_millis: int | None):
         """Receive a message from the consumer.
 
         Returns:
             Message: The received message.
         """
-        return self.consumer.receive()
+        try:
+            return self.consumer.receive(timeout_millis=timeout_millis)
+        except pulsar.Timeout:
+            raise Timeout()
 
     def acknowledge(self, msg):
         """Acknowledge a message on the consumer.

--- a/app/services/pulsar.py
+++ b/app/services/pulsar.py
@@ -1,6 +1,5 @@
 from cloudevents.events import CEMessageMode, Event, PulsarBinding
-import pulsar
-from pulsar import Client
+from pulsar import Client, Timeout as PulsarTimeout
 from viaa.configuration import ConfigParser
 from viaa.observability import logging
 
@@ -63,7 +62,7 @@ class PulsarClient:
         """
         try:
             return self.consumer.receive(timeout_millis=timeout_millis)
-        except pulsar.Timeout:
+        except PulsarTimeout:
             raise PulsarClientTimeoutException()
 
     def acknowledge(self, msg):

--- a/tests/containers/conftest.py
+++ b/tests/containers/conftest.py
@@ -50,7 +50,7 @@ def db_client(config_parser):
 def setup_schema(db_client):
     """Creates enum, table and trigger."""
     with open(
-        Path("..", "sipin_postgres", "sip_deliveries.ddl"), "r", encoding="utf-8"
+        Path("tests", "containers", "sipin_postgres", "sip_deliveries.ddl"), "r", encoding="utf-8"
     ) as ddl_file:
         ddl = ddl_file.read()
     with db_client.pool.connection() as conn:

--- a/tests/containers/test_graceful_shutdown.py
+++ b/tests/containers/test_graceful_shutdown.py
@@ -1,9 +1,9 @@
 import subprocess
-from pathlib import Path
 from time import sleep
 from signal import SIGINT, SIGTERM
 
 from app.app import RECEIVE_MESSAGE_TIMEOUT_IN_MS
+
 
 def test_graceful_shutdown_sigint(
     setup_schema,
@@ -35,6 +35,7 @@ def test_graceful_shutdown_sigint(
     sleep(RECEIVE_MESSAGE_TIMEOUT_IN_MS / 1000)
     exited = process.poll()
     assert exited == 0
+
 
 def test_graceful_shutdown_sigterm(
     setup_schema,

--- a/tests/containers/test_graceful_shutdown.py
+++ b/tests/containers/test_graceful_shutdown.py
@@ -1,0 +1,66 @@
+import subprocess
+from pathlib import Path
+from time import sleep
+from signal import SIGINT, SIGTERM
+
+def test_graceful_shutdown_sigint(
+    setup_schema,
+    db_client,
+    producer,
+    insert_sip_delivery,
+    outgoing_consumer,
+):
+    process = subprocess.Popen(
+        ["python", "-m", "main"],
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+    )
+
+    # Wait for a small amount of time, as there is probably a race condition between
+    # this process calling `process.send_signal` and the subprocess registering
+    # signal handlers.
+    sleep(1)
+    process.send_signal(SIGINT)
+
+    # Again, probably a race condition between the `process.poll()` and the process
+    # actually ending in case graceful shutdown fails.
+    sleep(1)
+    exited = process.poll()
+    assert exited is None
+
+    # After waiting for 60 seconds, without any messages coming in, the process
+    # should have finished regardless due to timeout.
+    sleep(60)
+    exited = process.poll()
+    assert exited == 0
+
+def test_graceful_shutdown_sigterm(
+    setup_schema,
+    db_client,
+    producer,
+    insert_sip_delivery,
+    outgoing_consumer,
+):
+    process = subprocess.Popen(
+        ["python", "-m", "main"],
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+    )
+
+    # Wait for a small amount of time, as there is probably a race condition between
+    # this process calling `process.send_signal` and the subprocess registering
+    # signal handlers.
+    sleep(1)
+    process.send_signal(SIGTERM)
+
+    # Again, probably a race condition between the `process.poll()` and the process
+    # actually ending in case graceful shutdown fails.
+    sleep(1)
+    exited = process.poll()
+    assert exited is None
+
+    # After waiting for 60 seconds, without any messages coming in, the process
+    # should have finished regardless due to timeout.
+    sleep(60)
+    exited = process.poll()
+    assert exited == 0

--- a/tests/containers/test_graceful_shutdown.py
+++ b/tests/containers/test_graceful_shutdown.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from time import sleep
 from signal import SIGINT, SIGTERM
 
+from app.app import RECEIVE_MESSAGE_TIMEOUT_IN_MS
+
 def test_graceful_shutdown_sigint(
     setup_schema,
     db_client,
@@ -28,9 +30,9 @@ def test_graceful_shutdown_sigint(
     exited = process.poll()
     assert exited is None
 
-    # After waiting for 60 seconds, without any messages coming in, the process
-    # should have finished regardless due to timeout.
-    sleep(60)
+    # After waiting for ~RECEIVE_MESSAGE_TIMEOUT_IN_MS milliseconds without any
+    # messages coming in, the process should have finished due to timeout.
+    sleep(RECEIVE_MESSAGE_TIMEOUT_IN_MS / 1000)
     exited = process.poll()
     assert exited == 0
 
@@ -59,8 +61,8 @@ def test_graceful_shutdown_sigterm(
     exited = process.poll()
     assert exited is None
 
-    # After waiting for 60 seconds, without any messages coming in, the process
-    # should have finished regardless due to timeout.
-    sleep(60)
+    # After waiting for ~RECEIVE_MESSAGE_TIMEOUT_IN_MS milliseconds without any
+    # messages coming in, the process should have finished due to timeout.
+    sleep(RECEIVE_MESSAGE_TIMEOUT_IN_MS / 1000)
     exited = process.poll()
     assert exited == 0

--- a/tests/containers/test_graceful_shutdown.py
+++ b/tests/containers/test_graceful_shutdown.py
@@ -24,17 +24,19 @@ def test_graceful_shutdown_sigint(
     sleep(1)
     process.send_signal(SIGINT)
 
-    # Again, probably a race condition between the `process.poll()` and the process
-    # actually ending in case graceful shutdown fails.
-    sleep(1)
-    exited = process.poll()
-    assert exited is None
+    # Check that the process ends in the allotted timeout period (+ 1 second
+    # to prevent race conditions between timeout and subprocess.)
+    try:
+        (out, _) = process.communicate(timeout=RECEIVE_MESSAGE_TIMEOUT_IN_MS / 1000 + 1)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        raise Exception("Process did not finish before timeout.")
 
-    # After waiting for ~RECEIVE_MESSAGE_TIMEOUT_IN_MS milliseconds without any
-    # messages coming in, the process should have finished due to timeout.
-    sleep(RECEIVE_MESSAGE_TIMEOUT_IN_MS / 1000)
-    exited = process.poll()
-    assert exited == 0
+    # Check for the log message created by the _stop function.
+    assert "received a stop signal. Attempting to shut down gracefully." in out
+
+    # Return code should be 0, it should not end due to e.g., an unhandled exception.
+    assert process.returncode == 0
 
 
 def test_graceful_shutdown_sigterm(
@@ -56,14 +58,16 @@ def test_graceful_shutdown_sigterm(
     sleep(1)
     process.send_signal(SIGTERM)
 
-    # Again, probably a race condition between the `process.poll()` and the process
-    # actually ending in case graceful shutdown fails.
-    sleep(1)
-    exited = process.poll()
-    assert exited is None
+    # Check that the process ends in the allotted timeout period (+ 1 second
+    # to prevent race conditions between timeout and subprocess.)
+    try:
+        (out, _) = process.communicate(timeout=RECEIVE_MESSAGE_TIMEOUT_IN_MS / 1000 + 1)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        raise Exception("Process did not finish before timeout.")
 
-    # After waiting for ~RECEIVE_MESSAGE_TIMEOUT_IN_MS milliseconds without any
-    # messages coming in, the process should have finished due to timeout.
-    sleep(RECEIVE_MESSAGE_TIMEOUT_IN_MS / 1000)
-    exited = process.poll()
-    assert exited == 0
+    # Check for the log message created by the _stop function.
+    assert "received a stop signal. Attempting to shut down gracefully." in out
+
+    # Return code should be 0, it should not end due to e.g., an unhandled exception.
+    assert process.returncode == 0


### PR DESCRIPTION
Gracefully shut down the service when a SIGINT or SIGTERM signal is received. This is done by:

1. Intermittently checking a `should_continue` variable as part of the main application loop. 
2. Ensuring that `receive_message` does not block indefinitely (as would be the case when there are no new messages). 
    - In order to accompish this a `timeout_millis` parameter is added to `PulsarClient.receive`. 
 
The current solution provides an upper bound of 60 seconds before `receive_message` stops waiting and returns to the main application loop. This means that the graceful shutdown will take at most 60 seconds + the time necessary to execute the rest of the `receive_message` logic in case a message is received.

This should be tested in INT to see whether is behaves properly.